### PR TITLE
Update types.py

### DIFF
--- a/bolt11/types.py
+++ b/bolt11/types.py
@@ -14,6 +14,7 @@ class LightningInvoice(NamedTuple):
     signature: "Signature"
     tags: Dict[str, Any]
     timestamp: int
+    expiry: int
     amount: Optional["MilliSatoshi"] = None
     route_hints: List["Route"] = []
 


### PR DESCRIPTION
# Return to invoice expiration.

Changes.

https://github.com/lnbits/bolt11/blob/master/bolt11/types.py

Add

```python
class LightningInvoice(NamedTuple):
    expiry: int
```




