### PR TITLE
FEAT: Backwards compatibility for amount_msat and date

### DIFF
--- a/bolt11/decode.py
+++ b/bolt11/decode.py
@@ -56,8 +56,8 @@ def decode(pr: str) -> Bolt11:
         tag, tagdata, data_part = _pull_tagged(data_part)
         data_length = len(tagdata or []) / 5  # type: ignore
 
-        # MUST skip over unknown fields, OR an f field with unknown version, OR p, h, s or n
-        # fields that do NOT have data_lengths of 52, 52, 52 or 53, respectively.
+        # MUST skip over unknown fields, OR an f field with unknown version, OR p, h,
+        # s or n fields that do NOT have data_lengths of 52, 52, 52 or 53, respectively.
 
         if tag == "p" and data_length == 52 and not hasattr(tags, "p"):
             tags["p"] = trim_to_bytes(tagdata).hex()  # type: ignore
@@ -85,9 +85,9 @@ def decode(pr: str) -> Bolt11:
 
     signature = Signature(signature_data=signature_data, signing_data=hrp.encode() + data_part.tobytes())
 
-    # A reader MUST check that the `signature` is valid (see the `n` tagged field specified below).
-    # A reader MUST use the `n` field to validate the signature instead of
-    # performing signature recovery if a valid `n` field is provided.
+    # A reader MUST check that the `signature` is valid (see the `n` tagged field
+    # specified below). A reader MUST use the `n` field to validate the signature
+    # instead of performing signature recovery if a valid `n` field is provided.
     if hasattr(tags, "n"):
         # TODO: research why no test runs this?
         signature.verify(tags["n"])
@@ -96,7 +96,7 @@ def decode(pr: str) -> Bolt11:
 
     return Bolt11(
         currency=currency,
-        amount=amount_msat,
+        amount_msat=amount_msat,
         timestamp=timestamp,
         signature=signature,
         tags=tags,

--- a/bolt11/decode.py
+++ b/bolt11/decode.py
@@ -97,7 +97,7 @@ def decode(pr: str) -> Bolt11:
     return Bolt11(
         currency=currency,
         amount_msat=amount_msat,
-        timestamp=timestamp,
+        date=timestamp,
         signature=signature,
         tags=tags,
     )

--- a/bolt11/encode.py
+++ b/bolt11/encode.py
@@ -51,7 +51,7 @@ def encode(invoice: Bolt11, private_key: Optional[str] = None) -> str:
     if not invoice.description and not invoice.description_hash:
         raise ValueError("Must include either 'd' or 'h'")
 
-    timestamp = BitArray(uint=invoice.timestamp, length=35)
+    timestamp = BitArray(uint=invoice.date, length=35)
     tags = BitArray()
 
     for k, tag in invoice.tags.items():

--- a/bolt11/encode.py
+++ b/bolt11/encode.py
@@ -37,10 +37,10 @@ def _tagged_int(tag: bytes):
     return value
 
 
-def _create_hrp(currency: str, amount: Optional[MilliSatoshi]) -> str:
+def _create_hrp(currency: str, amount_msat: Optional[MilliSatoshi]) -> str:
     hrp = "ln" + currency
-    if amount:
-        hrp += msat_to_amount(amount)
+    if amount_msat:
+        hrp += msat_to_amount(amount_msat)
     return hrp
 
 
@@ -79,7 +79,7 @@ def encode(invoice: Bolt11, private_key: Optional[str] = None) -> str:
         elif k == "r":
             tags += _tagged("r", tag.data)
 
-    hrp = _create_hrp(invoice.currency, invoice.amount)
+    hrp = _create_hrp(invoice.currency, invoice.amount_msat)
 
     if private_key:
         invoice.signature = Signature.from_private_key(private_key, hrp, timestamp + tags)

--- a/bolt11/types.py
+++ b/bolt11/types.py
@@ -34,7 +34,7 @@ class Bolt11:
     currency: str
     timestamp: int
     tags: Dict[str, Any]
-    amount: Optional[MilliSatoshi] = None
+    amount_msat: Optional[MilliSatoshi] = None
     signature: Optional[Signature] = None
 
     @property
@@ -89,7 +89,7 @@ class Bolt11:
     def json(self) -> str:
         json_data = {
             "currency": self.currency,
-            "amount": int(self.amount) if self.amount else 0,
+            "amount_msat": int(self.amount_msat) if self.amount_msat else 0,
             "timestamp": self.timestamp,
             "signature": self.signature.hex if self.signature else "",
         }

--- a/bolt11/types.py
+++ b/bolt11/types.py
@@ -32,7 +32,7 @@ class Bolt11:
     """Bolt11 Lightning invoice."""
 
     currency: str
-    timestamp: int
+    date: int
     tags: Dict[str, Any]
     amount_msat: Optional[MilliSatoshi] = None
     signature: Optional[Signature] = None
@@ -51,7 +51,7 @@ class Bolt11:
 
     @property
     def dt(self) -> datetime:
-        return datetime.fromtimestamp(self.timestamp)
+        return datetime.fromtimestamp(self.date)
 
     @property
     def expiry(self) -> Optional[int]:
@@ -90,7 +90,7 @@ class Bolt11:
         json_data = {
             "currency": self.currency,
             "amount_msat": int(self.amount_msat) if self.amount_msat else 0,
-            "timestamp": self.timestamp,
+            "date": self.date,
             "signature": self.signature.hex if self.signature else "",
         }
         if self.description:
@@ -120,7 +120,7 @@ class Bolt11:
     def has_expired(self) -> bool:
         if self.expiry is None:
             return False
-        return time.time() > self.timestamp + self.expiry
+        return time.time() > self.date + self.expiry
 
     def is_mainnet(self) -> bool:
         return self.currency == "bc"

--- a/tests/test_bolt11_examples.py
+++ b/tests/test_bolt11_examples.py
@@ -25,7 +25,7 @@ class TestBolt11:
                 "m9r9zqt8r2t7mlcwspyetp5h2tztugp9lfyql"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": None,
@@ -43,7 +43,7 @@ class TestBolt11:
         decoded = decode(ex["payment_request"])
 
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -60,7 +60,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "p": ex["payment_hash"],
@@ -84,7 +84,7 @@ class TestBolt11:
                 "dx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "expiry": 60,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
@@ -102,7 +102,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.expiry == ex["expiry"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
@@ -120,7 +120,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "p": ex["payment_hash"],
@@ -146,7 +146,7 @@ class TestBolt11:
                 "raedendscp573dxr"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "expiry": 60,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
@@ -164,7 +164,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.expiry == ex["expiry"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
@@ -182,7 +182,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "p": ex["payment_hash"],
@@ -208,7 +208,7 @@ class TestBolt11:
                 "erwnyutnjq7x39ymw6j38gp7ynn44"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_000_000_000,
@@ -226,7 +226,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -244,7 +244,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "p": ex["payment_hash"],
@@ -269,7 +269,7 @@ class TestBolt11:
                 "e9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8"
             ),
             "currency": "tb",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_000_000_000,
@@ -288,7 +288,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.fallback
@@ -308,7 +308,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "h": ex["description_hash"],
@@ -338,7 +338,7 @@ class TestBolt11:
                 "j4jwe7yj7vaf2k9lqsdk45kts2fd0fkr28am0u4w95tt2nsq76cqw0"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_000_000_000,
@@ -373,7 +373,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.fallback
@@ -402,7 +402,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "p": ex["payment_hash"],
@@ -429,7 +429,7 @@ class TestBolt11:
                 "dfqysuqypgqex4haa2h8fx3wnypranf3pdwyluftwe680jjcfp438u82xqphf75ym"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_000_000_000,
@@ -448,7 +448,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -468,7 +468,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "h": ex["description_hash"],
@@ -494,7 +494,7 @@ class TestBolt11:
                 "jjc7hljm98xhjym0dg52sdrvqamxdezkmqg4gdrvwwnf0kv2jdfnl4xatsqmrnsse"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_000_000_000,
@@ -513,7 +513,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -533,7 +533,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "h": ex["description_hash"],
@@ -559,7 +559,7 @@ class TestBolt11:
                 "nwc47xlrsnenq2zp70fq83qlgesn4u3uyf4tesfkkwwfg3qs54qe426hp3tz7z6sweqdjg05axsrjqp9yrrwc"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_000_000_000,
@@ -578,7 +578,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -598,7 +598,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "s": ex["payment_secret"],
                 "h": ex["description_hash"],
@@ -627,7 +627,7 @@ class TestBolt11:
                 "dxefsfvm0fq3sesf08uf6q9a2ke0hc9j6z6wlxg5z5kqpu2v9wz"
             ),
             "currency": "bc",
-            "timestamp": 1572468703,
+            "date": 1572468703,
             "payment_hash": "462264ede7e14047e9b249da94fefc47f41f7d02ee9b091815a5506bc8abf75f",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 967_878_534,
@@ -658,7 +658,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.expiry == ex["expiry"]
         assert decoded.min_final_cltv_expiry == ex["min_final_cltv_expiry"]
         assert decoded.payment_hash == ex["payment_hash"]
@@ -687,7 +687,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "p": ex["payment_hash"],
                 "d": ex["description"],
@@ -716,7 +716,7 @@ class TestBolt11:
                 "vcse3sgpz3uapa"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_500_000_000,
@@ -737,7 +737,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -754,7 +754,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "p": ex["payment_hash"],
                 "d": ex["description"],
@@ -779,7 +779,7 @@ class TestBolt11:
                 "VCSE3SGPZ3UAPA"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_500_000_000,
@@ -800,7 +800,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -817,7 +817,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "p": ex["payment_hash"],
                 "d": ex["description"],
@@ -849,7 +849,7 @@ class TestBolt11:
                 "hw6dlp3jhuhge9ley7j2ayx36kawe7kmgg8sv5ugdyusdcqzn8z9x"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 2_500_000_000,
@@ -870,7 +870,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -894,7 +894,7 @@ class TestBolt11:
                 "3vrdvruverwwq7yzhkf5a3xqpd05wjc"
             ),
             "currency": "bc",
-            "timestamp": 1496314658,
+            "date": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
             "amount_msat": 1_000_000_000,
@@ -916,7 +916,7 @@ class TestBolt11:
 
         decoded = decode(ex["payment_request"])
         assert decoded.currency == ex["currency"]
-        assert decoded.timestamp == ex["timestamp"]
+        assert decoded.date == ex["date"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.amount_msat == ex["amount_msat"]
@@ -934,7 +934,7 @@ class TestBolt11:
         invoice = Bolt11(
             currency=ex["currency"],
             amount_msat=ex["amount_msat"],
-            timestamp=ex["timestamp"],
+            date=ex["date"],
             tags={
                 "p": ex["payment_hash"],
                 "d": ex["description"],

--- a/tests/test_bolt11_examples.py
+++ b/tests/test_bolt11_examples.py
@@ -13,7 +13,7 @@ class TestBolt11:
 
     def test_example_1(self):
         """
-        Please make a donation of any amount using payment_hash
+        Please make a donation of any amount_msat using payment_hash
         0001020304050607080900010203040506070809000102030405060708090102
         to me @03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad
         """
@@ -28,7 +28,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": None,
+            "amount_msat": None,
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
             "description": "Please consider supporting this project",
             "features": {"var_onion_optin": "required", "payment_secret": "required"},
@@ -46,7 +46,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.payee == ex["payee"]
         assert decoded.features
@@ -59,7 +59,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -88,7 +88,7 @@ class TestBolt11:
             "expiry": 60,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 250_000_000,
+            "amount_msat": 250_000_000,
             "description": "1 cup coffee",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
             "features": {"var_onion_optin": "required", "payment_secret": "required"},
@@ -106,7 +106,7 @@ class TestBolt11:
         assert decoded.expiry == ex["expiry"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.payee == ex["payee"]
         assert decoded.features
@@ -119,7 +119,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -150,7 +150,7 @@ class TestBolt11:
             "expiry": 60,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 250_000_000,
+            "amount_msat": 250_000_000,
             "description": "ナンセンス 1杯",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
             "features": {"var_onion_optin": "required", "payment_secret": "required"},
@@ -168,7 +168,7 @@ class TestBolt11:
         assert decoded.expiry == ex["expiry"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.payee == ex["payee"]
         assert decoded.features
@@ -181,7 +181,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -211,7 +211,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_000_000_000,
+            "amount_msat": 2_000_000_000,
             "description": None,
             "description_hash": "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
@@ -229,7 +229,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.description_hash == ex["description_hash"]
         assert decoded.payee == ex["payee"]
@@ -243,7 +243,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -272,7 +272,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_000_000_000,
+            "amount_msat": 2_000_000_000,
             "description": None,
             "description_hash": "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
@@ -293,7 +293,7 @@ class TestBolt11:
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.fallback
         assert decoded.fallback.address == ex["fallback"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.description_hash == ex["description_hash"]
         assert decoded.payee == ex["payee"]
@@ -307,7 +307,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -341,7 +341,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_000_000_000,
+            "amount_msat": 2_000_000_000,
             "description": None,
             "description_hash": "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
@@ -378,7 +378,7 @@ class TestBolt11:
         assert decoded.payment_secret == ex["payment_secret"]
         assert decoded.fallback
         assert decoded.fallback.address == ex["fallback"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.description_hash == ex["description_hash"]
         assert decoded.payee == ex["payee"]
@@ -401,7 +401,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -432,7 +432,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_000_000_000,
+            "amount_msat": 2_000_000_000,
             "description": None,
             "description_hash": "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
@@ -451,7 +451,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.description_hash == ex["description_hash"]
         assert decoded.payee == ex["payee"]
@@ -467,7 +467,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -497,7 +497,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_000_000_000,
+            "amount_msat": 2_000_000_000,
             "description": None,
             "description_hash": "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
@@ -516,7 +516,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.description_hash == ex["description_hash"]
         assert decoded.payee == ex["payee"]
@@ -532,7 +532,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -562,7 +562,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_000_000_000,
+            "amount_msat": 2_000_000_000,
             "description": None,
             "description_hash": "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
@@ -581,7 +581,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.description_hash == ex["description_hash"]
         assert decoded.payee == ex["payee"]
@@ -597,7 +597,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "s": ex["payment_secret"],
@@ -614,7 +614,7 @@ class TestBolt11:
 
     def test_example_10(self):
         """
-        Please send 0.00967878534 BTC for a list of items within one week, amount in pico-BTC
+        Please send 0.00967878534 BTC for a list of items within one week, amount_msat in pico-BTC
         """
         ex = {
             "payment_request": (
@@ -630,7 +630,7 @@ class TestBolt11:
             "timestamp": 1572468703,
             "payment_hash": "462264ede7e14047e9b249da94fefc47f41f7d02ee9b091815a5506bc8abf75f",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 967_878_534,
+            "amount_msat": 967_878_534,
             "expiry": 604800,
             "min_final_cltv_expiry": 10,
             "description": (
@@ -663,7 +663,7 @@ class TestBolt11:
         assert decoded.min_final_cltv_expiry == ex["min_final_cltv_expiry"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.payee == ex["payee"]
         assert decoded.signature
@@ -686,7 +686,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "p": ex["payment_hash"],
@@ -719,7 +719,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_500_000_000,
+            "amount_msat": 2_500_000_000,
             "description": "coffee beans",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
             "features": {"var_onion_optin": "required", "payment_secret": "required", "extra_31": "supported"},
@@ -740,7 +740,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.payee == ex["payee"]
         assert decoded.signature
@@ -753,7 +753,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "p": ex["payment_hash"],
@@ -782,7 +782,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_500_000_000,
+            "amount_msat": 2_500_000_000,
             "description": "coffee beans",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
             "features": {"var_onion_optin": "required", "payment_secret": "required", "extra_31": "supported"},
@@ -803,7 +803,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.payee == ex["payee"]
         assert decoded.signature
@@ -816,7 +816,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "p": ex["payment_hash"],
@@ -852,7 +852,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 2_500_000_000,
+            "amount_msat": 2_500_000_000,
             "description": "coffee beans",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
             "features": {"var_onion_optin": "required", "payment_secret": "required", "extra_31": "supported"},
@@ -873,7 +873,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.payee == ex["payee"]
         assert not decoded.fallback
@@ -897,7 +897,7 @@ class TestBolt11:
             "timestamp": 1496314658,
             "payment_hash": "0001020304050607080900010203040506070809000102030405060708090102",
             "payment_secret": "1111111111111111111111111111111111111111111111111111111111111111",
-            "amount": 1_000_000_000,
+            "amount_msat": 1_000_000_000,
             "description": "payment metadata inside",
             "metadata": "01fafaf0",
             "payee": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
@@ -919,7 +919,7 @@ class TestBolt11:
         assert decoded.timestamp == ex["timestamp"]
         assert decoded.payment_hash == ex["payment_hash"]
         assert decoded.payment_secret == ex["payment_secret"]
-        assert decoded.amount == ex["amount"]
+        assert decoded.amount_msat == ex["amount_msat"]
         assert decoded.description == ex["description"]
         assert decoded.metadata == ex["metadata"]
         assert decoded.payee == ex["payee"]
@@ -933,7 +933,7 @@ class TestBolt11:
 
         invoice = Bolt11(
             currency=ex["currency"],
-            amount=ex["amount"],
+            amount_msat=ex["amount_msat"],
             timestamp=ex["timestamp"],
             tags={
                 "p": ex["payment_hash"],


### PR DESCRIPTION
reverting change of amount and timestamp, to be more compatible with previous versions.