### PR TITLE
chore(exception): remove unnecessary exception `Bolt11PrefixInvalidException`

### DIFF
--- a/bolt11/decode.py
+++ b/bolt11/decode.py
@@ -8,7 +8,6 @@ from bitstring import ConstBitStream
 from .bit_utils import trim_to_bytes, u5_to_bitarray
 from .exceptions import (
     Bolt11Bech32InvalidException,
-    Bolt11PrefixInvalidException,
     Bolt11SignatureTooShortException,
     Bolt11SignatureVerifyException,
 )
@@ -33,9 +32,6 @@ def decode(
     strict: bool = False,
 ) -> Bolt11:
     pr = pr.lower()
-
-    if not pr.startswith("ln"):
-        raise Bolt11PrefixInvalidException()
 
     hrp, bech32_data = bech32_decode(pr)
     if hrp is None or bech32_data is None:

--- a/bolt11/exceptions.py
+++ b/bolt11/exceptions.py
@@ -93,22 +93,22 @@ class Bolt11PrefixInvalidException(Bolt11Exception):
         super().__init__("Invalid Prefix, bolt11 should start with `ln`.")
 
 
-class Bolt11AmountInvalidException(Bolt11Exception):
+class Bolt11HrpInvalidException(Bolt11Exception):
+    """
+    Invalid Human Readable Part.
+    """
+
+    def __init__(self, message="Human readable part is not valid."):
+        super().__init__(message)
+
+
+class Bolt11AmountInvalidException(Bolt11HrpInvalidException):
     """
     Invalid shortened amount
     """
 
     def __init__(self):
         super().__init__("Invalid shortened amount.")
-
-
-class Bolt11HrpInvalidException(Bolt11Exception):
-    """
-    Invalid Human Readable Part.
-    """
-
-    def __init__(self):
-        super().__init__("Human readable part is not valid.")
 
 
 class Bolt11Bech32InvalidException(Bolt11Exception):

--- a/bolt11/exceptions.py
+++ b/bolt11/exceptions.py
@@ -84,15 +84,6 @@ class Bolt11SignatureTooShortException(Bolt11Exception):
         super().__init__("Too short to contain signature")
 
 
-class Bolt11PrefixInvalidException(Bolt11Exception):
-    """
-    Invalid Prefix, bolt11 should start with `ln`.
-    """
-
-    def __init__(self):
-        super().__init__("Invalid Prefix, bolt11 should start with `ln`.")
-
-
 class Bolt11HrpInvalidException(Bolt11Exception):
     """
     Invalid Human Readable Part.

--- a/bolt11/types.py
+++ b/bolt11/types.py
@@ -77,6 +77,9 @@ class Bolt11:
     def is_testnet(self) -> bool:
         return self.currency == "tb"
 
+    def is_signet(self) -> bool:
+        return self.currency == "tbs"
+
     def is_regtest(self) -> bool:
         return self.currency == "bcrt"
 

--- a/bolt11/utils.py
+++ b/bolt11/utils.py
@@ -10,8 +10,8 @@ def verify_hrp(hrp: str) -> tuple[str, Optional[MilliSatoshi]]:
     matches = match(r"ln(bcrt|bc|tbs|tb)(\w+)?", hrp)
     if matches is None:
         raise Bolt11HrpInvalidException()
-    curreny, amount_str = matches.groups()
-    return curreny, amount_to_msat(amount_str) if amount_str else None
+    currency, amount_str = matches.groups()
+    return currency, amount_to_msat(amount_str) if amount_str else None
 
 
 def amount_to_msat(amount: str) -> MilliSatoshi:

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -1,23 +1,21 @@
 import pytest
 
-from bolt11.decode import decode
 from bolt11.exceptions import (
     Bolt11AmountInvalidException,
     Bolt11HrpInvalidException,
-    Bolt11PrefixInvalidException,
 )
 from bolt11.utils import verify_hrp
 
 
-class TestInvalidPrefix:
+class TestInvalidHrp:
     @pytest.mark.parametrize(
-        "prefix",
-        ["nl", "lln", "10ln"],
+        "hrp",
+        ["nl", "lln", "10ln", "lnbcu"],
     )
-    def test_invalid_prefix(self, prefix):
+    def test_invalid_prefix(self, hrp):
         # Invalid Prefix, bolt11 should start with `ln`.
-        with pytest.raises(Bolt11PrefixInvalidException):
-            decode(prefix)
+        with pytest.raises(Bolt11HrpInvalidException):
+            verify_hrp(hrp)
 
 
 class TestVerifyHrp:


### PR DESCRIPTION
This PR removes the exception class `Bolt11PrefixInvalidException` as the behaviour is already covered by `Bolt11HrpInvalidException` or `Bolt11Bech32InvalidException` respectively.

Additionally, `Bolt11AmountInvalidException` now extends `Bolt11HrpInvalidException` as the amount is part of the hrp.

Hope this is in your interest. Any suggestion or comment is highly appreciated :pray: 

Addendum: Thank you for this lib :orange_heart: 