### PR TITLE
fix typing for python 3.8

### DIFF
--- a/bolt11/utils.py
+++ b/bolt11/utils.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 from re import fullmatch, match
-from typing import Optional, Union, Tuple
+from typing import Optional, Tuple, Union
 
 from .exceptions import Bolt11AmountInvalidException, Bolt11HrpInvalidException
 from .types import MilliSatoshi

--- a/bolt11/utils.py
+++ b/bolt11/utils.py
@@ -1,12 +1,12 @@
 from decimal import Decimal
 from re import fullmatch, match
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 
 from .exceptions import Bolt11AmountInvalidException, Bolt11HrpInvalidException
 from .types import MilliSatoshi
 
 
-def verify_hrp(hrp: str) -> tuple[str, Optional[MilliSatoshi]]:
+def verify_hrp(hrp: str) -> Tuple[str, Optional[MilliSatoshi]]:
     matches = match(r"ln(bcrt|bc|tbs|tb)(\w+)?", hrp)
     if matches is None:
         raise Bolt11HrpInvalidException()


### PR DESCRIPTION
**Observed behavior:** Install from pypi (`pip install bolt11`) succeeds, but `bolt11 decode` fails with `TypeError: 'type' object is not subscriptable` in `utils.py` on line:

```python
def verify_hrp(hrp: str) -> tuple[str, Optional[MilliSatoshi]]:
```

This occurs because subscripting the built-in `tuple` type with type hints is only supported in Python 3.9 and later. The type hint should be changed to `Tuple` from the `typing` module, which is supported in Python 3.8 and later. 

Since the pypi package lists support as >=3.8.1, this PR adds a simple way to bring support to 3.8. After applying the fix `blot11 decode` works.

#### On 3.8 - it fails
```
Python 3.8.10 (default, Nov 14 2022, 12:59:47) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.version
'3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]'
>>> tuple[str, int]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'type' object is not subscriptable
```

#### On 3.9 - it succeeds
```
Python 3.9.7 (default, Sep 16 2021, 13:09:58) 
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.version
'3.9.7 (default, Sep 16 2021, 13:09:58) \n[GCC 7.5.0]'
>>> tuple[str, int]
tuple[str, int]
```